### PR TITLE
Compile IDS Python wrapper under Windows

### DIFF
--- a/ids_core/ids_core.c
+++ b/ids_core/ids_core.c
@@ -171,6 +171,10 @@ static void timestamp_to_utc(UEYETIME *timestamp, struct tm *dest) {
 PyObject *image_info(ids_core_Camera *self, int image_id) {
     UEYEIMAGEINFO image_info;
     struct tm utc_timestamp;
+    PyObject *info, *device_timestamp, *timestamp, *digital_input;
+    PyObject *gpio1, *gpio2;
+    PyObject *frame_number, *camera_buffers, *used_camera_buffers;
+    PyObject *height, *width;
 
     int ret = is_GetImageInfo(self->handle, image_id, &image_info, sizeof(image_info));
     switch (ret) {
@@ -183,11 +187,11 @@ PyObject *image_info(ids_core_Camera *self, int image_id) {
 
     timestamp_to_utc(&image_info.TimestampSystem, &utc_timestamp);
 
-    PyObject *info = PyDict_New();
+    info = PyDict_New();
 
-    PyObject *device_timestamp =
+    device_timestamp =
         Py_BuildValue("K", image_info.u64TimestampDevice);
-    PyObject *timestamp = /* Assume milliseconds don't change across timezone */
+    timestamp = /* Assume milliseconds don't change across timezone */
         PyDateTime_FromDateAndTime(utc_timestamp.tm_year + 1900,
                                    utc_timestamp.tm_mon + 1,
                                    utc_timestamp.tm_mday,
@@ -195,15 +199,15 @@ PyObject *image_info(ids_core_Camera *self, int image_id) {
                                    utc_timestamp.tm_min,
                                    utc_timestamp.tm_sec,
                                    1000*image_info.TimestampSystem.wMilliseconds);
-    PyObject *digital_input = Py_BuildValue("I", image_info.dwIoStatus&4);
-    PyObject *gpio1 = Py_BuildValue("I", image_info.dwIoStatus&2);
-    PyObject *gpio2 = Py_BuildValue("I", image_info.dwIoStatus&1);
-    PyObject *frame_number = Py_BuildValue("K", image_info.u64FrameNumber);
-    PyObject *camera_buffers = Py_BuildValue("I", image_info.dwImageBuffers);
-    PyObject *used_camera_buffers =
+    digital_input = Py_BuildValue("I", image_info.dwIoStatus&4);
+    gpio1 = Py_BuildValue("I", image_info.dwIoStatus&2);
+    gpio2 = Py_BuildValue("I", image_info.dwIoStatus&1);
+    frame_number = Py_BuildValue("K", image_info.u64FrameNumber);
+    camera_buffers = Py_BuildValue("I", image_info.dwImageBuffers);
+    used_camera_buffers =
         Py_BuildValue("I", image_info.dwImageBuffersInUse);
-    PyObject *height = Py_BuildValue("I", image_info.dwImageHeight);
-    PyObject *width = Py_BuildValue("I", image_info.dwImageWidth);
+    height = Py_BuildValue("I", image_info.dwImageHeight);
+    width = Py_BuildValue("I", image_info.dwImageWidth);
 
     PyDict_SetItemString(info, "device_timestamp", device_timestamp);
     PyDict_SetItemString(info, "timestamp", timestamp);

--- a/ids_core/ids_core.h
+++ b/ids_core/ids_core.h
@@ -2,6 +2,7 @@
 #define IDS_H_INCLUDED
 
 #include <sys/queue.h>
+#include <stdint.h>
 
 /* Module methods */
 extern PyMethodDef ids_coreMethods[];
@@ -15,7 +16,7 @@ struct allocated_mem {
 
 /* Camera class */
 typedef struct {
-    PyObject_HEAD;
+    PyObject_HEAD
     /* Externally available elements (in Python) */
     HIDS                    handle;
     uint32_t                width;

--- a/ids_core/ids_core_Camera.c
+++ b/ids_core/ids_core_Camera.c
@@ -152,6 +152,7 @@ static int init_cam_info(ids_core_Camera *self) {
 
 static int ids_core_Camera_init(ids_core_Camera *self, PyObject *args, PyObject *kwds) {
     static char *kwlist[] = {"handle", "color", NULL};
+    int ret;
     self->handle = 0;
     self->bitdepth = 0;
     self->color = IS_CM_RGB8_PACKED;
@@ -168,7 +169,7 @@ static int ids_core_Camera_init(ids_core_Camera *self, PyObject *args, PyObject 
         return -1;
     }
 
-    int ret = is_InitCamera(&self->handle, NULL);
+    ret = is_InitCamera(&self->handle, NULL);
     switch (ret) {
     case IS_SUCCESS:
         break;

--- a/ids_core/ids_core_Camera_attributes.c
+++ b/ids_core/ids_core_Camera_attributes.c
@@ -34,6 +34,7 @@
 PyObject *ids_core_Camera_getinfo(ids_core_Camera *self, void *closure) {
     CAMINFO cam_info;
     SENSORINFO sensor_info;
+    PyObject *dict;
 
     int ret = is_GetCameraInfo(self->handle, &cam_info);
     if (ret != IS_SUCCESS) {
@@ -47,126 +48,127 @@ PyObject *ids_core_Camera_getinfo(ids_core_Camera *self, void *closure) {
         return NULL;
     }
 
-    PyObject *dict = PyDict_New();
+    dict = PyDict_New();
+    {
+      PyObject *serial_num = PyBytes_FromString(cam_info.SerNo);
+      PyObject *manufacturer = PyBytes_FromString(cam_info.ID);
+      PyObject *hw_version = PyBytes_FromString(cam_info.Version);
+      PyObject *manufacture_date = PyBytes_FromString(cam_info.Date);
+      PyObject *id = Py_BuildValue("B", cam_info.Select);
+      PyObject *sensor_id = Py_BuildValue("H", sensor_info.SensorID);
+      PyObject *sensor_name = PyBytes_FromString(sensor_info.strSensorName);
+      PyObject *max_width = Py_BuildValue("I", sensor_info.nMaxWidth);
+      PyObject *max_height = Py_BuildValue("I", sensor_info.nMaxHeight);
+      PyObject *pixel_size = Py_BuildValue("d", sensor_info.wPixelSize/100.0);
+      PyObject *type;
+      PyObject *color_mode;
+      
+      switch (cam_info.Type) {
+      case IS_CAMERA_TYPE_UEYE_USB_SE:
+          type = PyBytes_FromString("USB uEye SE or RE");
+          break;
+      case IS_CAMERA_TYPE_UEYE_USB_ME:
+          type = PyBytes_FromString("USB uEye ME");
+          break;
+      case IS_CAMERA_TYPE_UEYE_USB_LE:
+          type = PyBytes_FromString("USB uEye LE");
+          break;
+      case IS_CAMERA_TYPE_UEYE_USB3_CP:
+          type = PyBytes_FromString("USB 3 uEye CP");
+          break;
+      case IS_CAMERA_TYPE_UEYE_ETH_HE:
+          type = PyBytes_FromString("GigE uEye HE");
+          break;
+      case IS_CAMERA_TYPE_UEYE_ETH_SE:
+          type = PyBytes_FromString("GigE uEye SE or RE");
+          break;
+      case IS_CAMERA_TYPE_UEYE_ETH_LE:
+          type = PyBytes_FromString("GigE uEye LE");
+          break;
+      case IS_CAMERA_TYPE_UEYE_ETH_CP:
+          type = PyBytes_FromString("GigE uEye CP");
+          break;
+      default:
+          type = PyBytes_FromString("Unknown");
+      }
 
-    PyObject *serial_num = PyBytes_FromString(cam_info.SerNo);
-    PyObject *manufacturer = PyBytes_FromString(cam_info.ID);
-    PyObject *hw_version = PyBytes_FromString(cam_info.Version);
-    PyObject *manufacture_date = PyBytes_FromString(cam_info.Date);
-    PyObject *id = Py_BuildValue("B", cam_info.Select);
-    PyObject *sensor_id = Py_BuildValue("H", sensor_info.SensorID);
-    PyObject *sensor_name = PyBytes_FromString(sensor_info.strSensorName);
-    PyObject *max_width = Py_BuildValue("I", sensor_info.nMaxWidth);
-    PyObject *max_height = Py_BuildValue("I", sensor_info.nMaxHeight);
-    PyObject *pixel_size = Py_BuildValue("d", sensor_info.wPixelSize/100.0);
+      switch (sensor_info.nColorMode) {
+      case IS_COLORMODE_BAYER:
+          color_mode = PyBytes_FromString("Bayer");
+          break;
+      case IS_COLORMODE_MONOCHROME:
+          color_mode = PyBytes_FromString("Monochrome");
+          break;
+      case IS_COLORMODE_CBYCRY:
+          color_mode = PyBytes_FromString("CBYCRY");
+          break;
+      default:
+          color_mode = PyBytes_FromString("Unknown");
+      }
 
-    PyObject *type;
-    switch (cam_info.Type) {
-    case IS_CAMERA_TYPE_UEYE_USB_SE:
-        type = PyBytes_FromString("USB uEye SE or RE");
-        break;
-    case IS_CAMERA_TYPE_UEYE_USB_ME:
-        type = PyBytes_FromString("USB uEye ME");
-        break;
-    case IS_CAMERA_TYPE_UEYE_USB_LE:
-        type = PyBytes_FromString("USB uEye LE");
-        break;
-    case IS_CAMERA_TYPE_UEYE_USB3_CP:
-        type = PyBytes_FromString("USB 3 uEye CP");
-        break;
-    case IS_CAMERA_TYPE_UEYE_ETH_HE:
-        type = PyBytes_FromString("GigE uEye HE");
-        break;
-    case IS_CAMERA_TYPE_UEYE_ETH_SE:
-        type = PyBytes_FromString("GigE uEye SE or RE");
-        break;
-    case IS_CAMERA_TYPE_UEYE_ETH_LE:
-        type = PyBytes_FromString("GigE uEye LE");
-        break;
-    case IS_CAMERA_TYPE_UEYE_ETH_CP:
-        type = PyBytes_FromString("GigE uEye CP");
-        break;
-    default:
-        type = PyBytes_FromString("Unknown");
-    }
+      PyDict_SetItemString(dict, "serial_num", serial_num);
+      PyDict_SetItemString(dict, "manufacturer", manufacturer);
+      PyDict_SetItemString(dict, "hw_version", hw_version);
+      PyDict_SetItemString(dict, "manufacture_date", manufacture_date);
+      PyDict_SetItemString(dict, "id", id);
+      PyDict_SetItemString(dict, "sensor_id", sensor_id);
+      PyDict_SetItemString(dict, "sensor_name", sensor_name);
+      PyDict_SetItemString(dict, "max_width", max_width);
+      PyDict_SetItemString(dict, "max_height", max_height);
+      PyDict_SetItemString(dict, "type", type);
+      PyDict_SetItemString(dict, "color_mode", color_mode);
+      PyDict_SetItemString(dict, "pixel_size", pixel_size);   /* in um */
 
-    PyObject *color_mode;
-    switch (sensor_info.nColorMode) {
-    case IS_COLORMODE_BAYER:
-        color_mode = PyBytes_FromString("Bayer");
-        break;
-    case IS_COLORMODE_MONOCHROME:
-        color_mode = PyBytes_FromString("Monochrome");
-        break;
-    case IS_COLORMODE_CBYCRY:
-        color_mode = PyBytes_FromString("CBYCRY");
-        break;
-    default:
-        color_mode = PyBytes_FromString("Unknown");
-    }
+      /* Gains */
+      if (sensor_info.bMasterGain) {
+          PyDict_SetItemString(dict, "master_gain", Py_True);
+      }
+      else {
+          PyDict_SetItemString(dict, "master_gain", Py_False);
+      }
 
-    PyDict_SetItemString(dict, "serial_num", serial_num);
-    PyDict_SetItemString(dict, "manufacturer", manufacturer);
-    PyDict_SetItemString(dict, "hw_version", hw_version);
-    PyDict_SetItemString(dict, "manufacture_date", manufacture_date);
-    PyDict_SetItemString(dict, "id", id);
-    PyDict_SetItemString(dict, "sensor_id", sensor_id);
-    PyDict_SetItemString(dict, "sensor_name", sensor_name);
-    PyDict_SetItemString(dict, "max_width", max_width);
-    PyDict_SetItemString(dict, "max_height", max_height);
-    PyDict_SetItemString(dict, "type", type);
-    PyDict_SetItemString(dict, "color_mode", color_mode);
-    PyDict_SetItemString(dict, "pixel_size", pixel_size);   /* in um */
+      if (sensor_info.bRGain) {
+          PyDict_SetItemString(dict, "red_gain", Py_True);
+      }
+      else {
+          PyDict_SetItemString(dict, "red_gain", Py_False);
+      }
 
-    /* Gains */
-    if (sensor_info.bMasterGain) {
-        PyDict_SetItemString(dict, "master_gain", Py_True);
-    }
-    else {
-        PyDict_SetItemString(dict, "master_gain", Py_False);
-    }
+      if (sensor_info.bGGain) {
+          PyDict_SetItemString(dict, "green_gain", Py_True);
+      }
+      else {
+          PyDict_SetItemString(dict, "green_gain", Py_False);
+      }
 
-    if (sensor_info.bRGain) {
-        PyDict_SetItemString(dict, "red_gain", Py_True);
-    }
-    else {
-        PyDict_SetItemString(dict, "red_gain", Py_False);
-    }
+      if (sensor_info.bBGain) {
+          PyDict_SetItemString(dict, "blue_gain", Py_True);
+      }
+      else {
+          PyDict_SetItemString(dict, "blue_gain", Py_False);
+      }
 
-    if (sensor_info.bGGain) {
-        PyDict_SetItemString(dict, "green_gain", Py_True);
-    }
-    else {
-        PyDict_SetItemString(dict, "green_gain", Py_False);
-    }
+      /* Global shutter, rolling if false */
+      if (sensor_info.bGlobShutter) {
+          PyDict_SetItemString(dict, "global_shutter", Py_True);
+      }
+      else {
+          PyDict_SetItemString(dict, "global_shutter", Py_False);
+      }
 
-    if (sensor_info.bBGain) {
-        PyDict_SetItemString(dict, "blue_gain", Py_True);
+      Py_DECREF(serial_num);
+      Py_DECREF(manufacturer);
+      Py_DECREF(hw_version);
+      Py_DECREF(manufacture_date);
+      Py_DECREF(id);
+      Py_DECREF(sensor_id);
+      Py_DECREF(sensor_name);
+      Py_DECREF(max_width);
+      Py_DECREF(max_height);
+      Py_DECREF(type);
+      Py_DECREF(color_mode);
+      Py_DECREF(pixel_size);
     }
-    else {
-        PyDict_SetItemString(dict, "blue_gain", Py_False);
-    }
-
-    /* Global shutter, rolling if false */
-    if (sensor_info.bGlobShutter) {
-        PyDict_SetItemString(dict, "global_shutter", Py_True);
-    }
-    else {
-        PyDict_SetItemString(dict, "global_shutter", Py_False);
-    }
-
-    Py_DECREF(serial_num);
-    Py_DECREF(manufacturer);
-    Py_DECREF(hw_version);
-    Py_DECREF(manufacture_date);
-    Py_DECREF(id);
-    Py_DECREF(sensor_id);
-    Py_DECREF(sensor_name);
-    Py_DECREF(max_width);
-    Py_DECREF(max_height);
-    Py_DECREF(type);
-    Py_DECREF(color_mode);
-    Py_DECREF(pixel_size);
 
     return dict;
 }
@@ -395,6 +397,9 @@ static PyObject *ids_core_Camera_getauto_exposure(ids_core_Camera *self, void *c
 }
 
 static int ids_core_Camera_setauto_exposure(ids_core_Camera *self, PyObject *value, void *closure) {
+    double val;
+    int ret;
+    
     if (value == NULL) {
         PyErr_SetString(PyExc_TypeError, "Cannot delete attribute 'auto_exposure'");
         return -1;
@@ -405,9 +410,9 @@ static int ids_core_Camera_setauto_exposure(ids_core_Camera *self, PyObject *val
         return -1;
     }
 
-    double val = (value == Py_True) ? 1 : 0;
+    val = (value == Py_True) ? 1 : 0;
 
-    int ret = is_SetAutoParameter(self->handle, IS_SET_ENABLE_AUTO_SHUTTER, &val, NULL);
+    ret = is_SetAutoParameter(self->handle, IS_SET_ENABLE_AUTO_SHUTTER, &val, NULL);
     switch (ret) {
     case IS_SUCCESS:
         if (val > 0) {

--- a/ids_core/ids_core_Camera_methods.c
+++ b/ids_core/ids_core_Camera_methods.c
@@ -311,7 +311,8 @@ static PyObject *create_matrix(ids_core_Camera *self, char *mem) {
     PyArrayObject* matrix;
 
     switch (color) {
-    case IS_CM_SENSOR_RAW8: {
+    case IS_CM_SENSOR_RAW8:
+    case IS_CM_MONO8: {
         npy_intp dims[2];
         dims[0] = self->height;
         dims[1] = self->width;
@@ -321,7 +322,10 @@ static PyObject *create_matrix(ids_core_Camera *self, char *mem) {
         break; 
     }
     case IS_CM_SENSOR_RAW12: /* You need to left shift the output by 4 bits */
-    case IS_CM_SENSOR_RAW16: {
+    case IS_CM_SENSOR_RAW16:
+    case IS_CM_MONO10:
+    case IS_CM_MONO12:
+    case IS_CM_MONO16: {
         npy_intp dims[2];
         dims[0] = self->height;
         dims[1] = self->width;

--- a/ids_core/ids_core_Camera_methods.c
+++ b/ids_core/ids_core_Camera_methods.c
@@ -45,6 +45,7 @@ static PyObject *create_matrix(ids_core_Camera *self, char *mem);
 
 static PyObject *ids_core_Camera_capture_status(ids_core_Camera *self, PyObject *args, PyObject *kwds) {
     int ret;
+    PyObject *dict;
     UEYE_CAPTURE_STATUS_INFO capture_status;
 
     ret = is_CaptureStatus(self->handle, IS_CAPTURE_STATUS_INFO_CMD_GET,
@@ -53,48 +54,50 @@ static PyObject *ids_core_Camera_capture_status(ids_core_Camera *self, PyObject 
         raise_general_error(self, ret);
     }
 
-    PyObject *dict = PyDict_New();
-    PyObject *total = Py_BuildValue("I", capture_status.dwCapStatusCnt_Total);
-    PyObject *no_destination_mem = Py_BuildValue("I",
-            capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_API_NO_DEST_MEM]);
-    PyObject *conversion_failed = Py_BuildValue("I",
-            capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_API_CONVERSION_FAILED]);
-    PyObject *image_locked = Py_BuildValue("I",
-            capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_API_IMAGE_LOCKED]);
-    PyObject *no_driver_mem = Py_BuildValue("I",
-            capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_DRV_OUT_OF_BUFFERS]);
-    PyObject *device_not_available = Py_BuildValue("I",
-            capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_DRV_DEVICE_NOT_READY]);
-    PyObject *usb_transfer_failed = Py_BuildValue("I",
-            capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_USB_TRANSFER_FAILED]);
-    PyObject *device_timeout = Py_BuildValue("I",
-            capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_DEV_TIMEOUT]);
-    PyObject *eth_buffer_overrun = Py_BuildValue("I",
-            capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_ETH_BUFFER_OVERRUN]);
-    PyObject *eth_missed_images = Py_BuildValue("I",
-            capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_ETH_MISSED_IMAGES]);
+    dict = PyDict_New();
+    {
+      PyObject *total = Py_BuildValue("I", capture_status.dwCapStatusCnt_Total);
+      PyObject *no_destination_mem = Py_BuildValue("I",
+              capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_API_NO_DEST_MEM]);
+      PyObject *conversion_failed = Py_BuildValue("I",
+              capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_API_CONVERSION_FAILED]);
+      PyObject *image_locked = Py_BuildValue("I",
+              capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_API_IMAGE_LOCKED]);
+      PyObject *no_driver_mem = Py_BuildValue("I",
+              capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_DRV_OUT_OF_BUFFERS]);
+      PyObject *device_not_available = Py_BuildValue("I",
+              capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_DRV_DEVICE_NOT_READY]);
+      PyObject *usb_transfer_failed = Py_BuildValue("I",
+              capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_USB_TRANSFER_FAILED]);
+      PyObject *device_timeout = Py_BuildValue("I",
+              capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_DEV_TIMEOUT]);
+      PyObject *eth_buffer_overrun = Py_BuildValue("I",
+              capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_ETH_BUFFER_OVERRUN]);
+      PyObject *eth_missed_images = Py_BuildValue("I",
+              capture_status.adwCapStatusCnt_Detail[IS_CAP_STATUS_ETH_MISSED_IMAGES]);
 
-    PyDict_SetItemString(dict, "total", total);
-    PyDict_SetItemString(dict, "no_destination_mem", no_destination_mem);
-    PyDict_SetItemString(dict, "conversion_failed", conversion_failed);
-    PyDict_SetItemString(dict, "image_locked", image_locked);
-    PyDict_SetItemString(dict, "no_driver_mem", no_driver_mem);
-    PyDict_SetItemString(dict, "device_not_available", device_not_available);
-    PyDict_SetItemString(dict, "usb_transfer_failed", usb_transfer_failed);
-    PyDict_SetItemString(dict, "device_timeout", device_timeout);
-    PyDict_SetItemString(dict, "eth_buffer_overrun", eth_buffer_overrun);
-    PyDict_SetItemString(dict, "eth_missed_images", eth_missed_images);
+      PyDict_SetItemString(dict, "total", total);
+      PyDict_SetItemString(dict, "no_destination_mem", no_destination_mem);
+      PyDict_SetItemString(dict, "conversion_failed", conversion_failed);
+      PyDict_SetItemString(dict, "image_locked", image_locked);
+      PyDict_SetItemString(dict, "no_driver_mem", no_driver_mem);
+      PyDict_SetItemString(dict, "device_not_available", device_not_available);
+      PyDict_SetItemString(dict, "usb_transfer_failed", usb_transfer_failed);
+      PyDict_SetItemString(dict, "device_timeout", device_timeout);
+      PyDict_SetItemString(dict, "eth_buffer_overrun", eth_buffer_overrun);
+      PyDict_SetItemString(dict, "eth_missed_images", eth_missed_images);
 
-    Py_DECREF(total);
-    Py_DECREF(no_destination_mem);
-    Py_DECREF(conversion_failed);
-    Py_DECREF(image_locked);
-    Py_DECREF(no_driver_mem);
-    Py_DECREF(device_not_available);
-    Py_DECREF(usb_transfer_failed);
-    Py_DECREF(device_timeout);
-    Py_DECREF(eth_buffer_overrun);
-    Py_DECREF(eth_missed_images);
+      Py_DECREF(total);
+      Py_DECREF(no_destination_mem);
+      Py_DECREF(conversion_failed);
+      Py_DECREF(image_locked);
+      Py_DECREF(no_driver_mem);
+      Py_DECREF(device_not_available);
+      Py_DECREF(usb_transfer_failed);
+      Py_DECREF(device_timeout);
+      Py_DECREF(eth_buffer_overrun);
+      Py_DECREF(eth_missed_images);
+    }
 
     /* Reset errors */
     ret = is_CaptureStatus(self->handle, IS_CAPTURE_STATUS_INFO_CMD_RESET, NULL, 0);
@@ -205,6 +208,11 @@ static PyObject *ids_core_Camera_next_save(ids_core_Camera *self, PyObject *args
     wchar_t fancy_filename[256];
     int filetype = IS_IMG_JPG;
     unsigned int quality = 100;
+    int ret;
+    char *mem;
+    INT image_id;
+    IMAGE_FILE_PARAMS ImageFileParams;
+    PyObject *info;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|iI", kwlist, &filename, &filetype, &quality)) {
         return NULL;
@@ -216,17 +224,12 @@ static PyObject *ids_core_Camera_next_save(ids_core_Camera *self, PyObject *args
         PyErr_SetString(PyExc_ValueError, "Invalid image filetype");
     }
 
-    int ret;
-    char *mem;
-    INT image_id;
-
     ret = get_next_image(self, &mem, &image_id);
     if (ret) {
         /* Exception set, return */
         return NULL;
     }
 
-    IMAGE_FILE_PARAMS ImageFileParams;
     ImageFileParams.pwchFileName = fancy_filename;
     ImageFileParams.nFileType = filetype;
     ImageFileParams.nQuality = quality;
@@ -241,7 +244,7 @@ static PyObject *ids_core_Camera_next_save(ids_core_Camera *self, PyObject *args
         return NULL;
     }
 
-    PyObject *info = image_info(self, image_id);
+    info = image_info(self, image_id);
     if (!info) {
         return NULL;
     }
@@ -263,6 +266,7 @@ static PyObject *ids_core_Camera_next(ids_core_Camera *self, PyObject *args, PyO
     int ret;
     char *mem;
     INT image_id;
+    PyObject *image, *info, *tuple;
 
     ret = get_next_image(self, &mem, &image_id);
     if (ret) {
@@ -270,12 +274,12 @@ static PyObject *ids_core_Camera_next(ids_core_Camera *self, PyObject *args, PyO
         return NULL;
     }
 
-    PyObject *image = create_matrix(self, mem);
+    image = create_matrix(self, mem);
     if (!image) {
         return NULL;
     }
 
-    PyObject *info = image_info(self, image_id);
+    info = image_info(self, image_id);
     if (!info) {
         Py_DECREF(image);
         return NULL;
@@ -292,7 +296,7 @@ static PyObject *ids_core_Camera_next(ids_core_Camera *self, PyObject *args, PyO
         return NULL;
     }
 
-    PyObject *tuple = Py_BuildValue("(OO)", image, info);
+    tuple = Py_BuildValue("(OO)", image, info);
 
     /* BuildValue INCREF's these objects, but we don't need them anymore */
     Py_DECREF(image);

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,18 @@
 from distutils.core import setup, Extension
 
 ids_core = Extension("ids_core",
-                     extra_compile_args = ['-std=gnu99', '-g3'],
-                     library_dirs = ['/usr/local/lib/'],
-                     libraries = ['ueye_api', 'm', 'z'],
+                     extra_compile_args = [],
+                     define_macros = [
+                        ('_IDS_EXPORT', None),
+                        ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')
+                     ],
+                     library_dirs = ['C:/Program Files/IDS/uEye/Develop/Lib'],
+                     include_dirs = [
+                        '.',
+                        'C:/Program Files/IDS/uEye/Develop/include',
+                        'C:/Anaconda3/Lib/site-packages/numpy/core/include'
+                     ],
+                     libraries = ['ueye_api', 'ueye_tools'],
                      sources = [
                             'ids_core/ids_core.c',
                             'ids_core/ids_core_methods.c',

--- a/setup.py
+++ b/setup.py
@@ -26,29 +26,40 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from distutils.core import setup, Extension
+import sys
 
-ids_core = Extension("ids_core",
-                     extra_compile_args = [],
-                     define_macros = [
-                        ('_IDS_EXPORT', None),
-                        ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')
-                     ],
-                     library_dirs = ['C:/Program Files/IDS/uEye/Develop/Lib'],
-                     include_dirs = [
-                        '.',
-                        'C:/Program Files/IDS/uEye/Develop/include',
-                        'C:/Anaconda3/Lib/site-packages/numpy/core/include'
-                     ],
-                     libraries = ['ueye_api', 'ueye_tools'],
-                     sources = [
-                            'ids_core/ids_core.c',
-                            'ids_core/ids_core_methods.c',
-                            'ids_core/ids_core_constants.c',
-                            'ids_core/ids_core_Camera.c',
-                            'ids_core/ids_core_Camera_methods.c',
-                            'ids_core/ids_core_Camera_attributes.c',
-                            'ids_core/ids_core_color.c',
-                     ])
+if sys.platform == "win32":
+  args = {
+    'extra_compile_args': [],
+    'define_macros': [
+      ('_IDS_EXPORT', None),
+      ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')
+    ],
+    'library_dirs': ['C:/Program Files/IDS/uEye/Develop/Lib'],
+    'libraries': ['ueye_api', 'ueye_tools'],
+    'include_dirs': [
+      '.',
+      'C:/Program Files/IDS/uEye/Develop/include',
+      'C:/Anaconda3/Lib/site-packages/numpy/core/include'
+    ]
+  }
+else:
+  args = {
+    'extra_compile_args': ['-std=gnu99', '-g3'],
+    'library_dirs': ['/usr/local/lib/'],
+    'libraries': ['ueye_api', 'm', 'z']
+  }
+# Platform-independent args.
+args['sources'] = [
+  'ids_core/ids_core.c',
+  'ids_core/ids_core_methods.c',
+  'ids_core/ids_core_constants.c',
+  'ids_core/ids_core_Camera.c',
+  'ids_core/ids_core_Camera_methods.c',
+  'ids_core/ids_core_Camera_attributes.c',
+  'ids_core/ids_core_color.c',
+]
+ids_core = Extension("ids_core", **args)
 
 setup(name = 'ids',
       version = '1.0',

--- a/sys/queue.h
+++ b/sys/queue.h
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)queue.h	8.5 (Berkeley) 8/20/94
+ */
+
+#ifndef	_SYS_QUEUE_H_
+#define	_SYS_QUEUE_H_
+
+/*
+ * This file defines five types of data structures: singly-linked lists,
+ * lists, simple queues, tail queues, and circular queues.
+ *
+ * A singly-linked list is headed by a single forward pointer. The
+ * elements are singly linked for minimum space and pointer manipulation
+ * overhead at the expense of O(n) removal for arbitrary elements. New
+ * elements can be added to the list after an existing element or at the
+ * head of the list.  Elements being removed from the head of the list
+ * should use the explicit macro for this purpose for optimum
+ * efficiency. A singly-linked list may only be traversed in the forward
+ * direction.  Singly-linked lists are ideal for applications with large
+ * datasets and few or no removals or for implementing a LIFO queue.
+ *
+ * A list is headed by a single forward pointer (or an array of forward
+ * pointers for a hash table header). The elements are doubly linked
+ * so that an arbitrary element can be removed without a need to
+ * traverse the list. New elements can be added to the list before
+ * or after an existing element or at the head of the list. A list
+ * may only be traversed in the forward direction.
+ *
+ * A simple queue is headed by a pair of pointers, one the head of the
+ * list and the other to the tail of the list. The elements are singly
+ * linked to save space, so elements can only be removed from the
+ * head of the list. New elements can be added to the list after
+ * an existing element, at the head of the list, or at the end of the
+ * list. A simple queue may only be traversed in the forward direction.
+ *
+ * A tail queue is headed by a pair of pointers, one to the head of the
+ * list and the other to the tail of the list. The elements are doubly
+ * linked so that an arbitrary element can be removed without a need to
+ * traverse the list. New elements can be added to the list before or
+ * after an existing element, at the head of the list, or at the end of
+ * the list. A tail queue may be traversed in either direction.
+ *
+ * A circle queue is headed by a pair of pointers, one to the head of the
+ * list and the other to the tail of the list. The elements are doubly
+ * linked so that an arbitrary element can be removed without a need to
+ * traverse the list. New elements can be added to the list before or after
+ * an existing element, at the head of the list, or at the end of the list.
+ * A circle queue may be traversed in either direction, but has a more
+ * complex end of list detection.
+ *
+ * For details on the use of these macros, see the queue(3) manual page.
+ */
+
+/*
+ * List definitions.
+ */
+#define	LIST_HEAD(name, type)						\
+struct name {								\
+	struct type *lh_first;	/* first element */			\
+}
+
+#define	LIST_HEAD_INITIALIZER(head)					\
+	{ NULL }
+
+#define	LIST_ENTRY(type)						\
+struct {								\
+	struct type *le_next;	/* next element */			\
+	struct type **le_prev;	/* address of previous next element */	\
+}
+
+/*
+ * List functions.
+ */
+#define	LIST_INIT(head) do {						\
+	(head)->lh_first = NULL;					\
+} while (/*CONSTCOND*/0)
+
+#define	LIST_INSERT_AFTER(listelm, elm, field) do {			\
+	if (((elm)->field.le_next = (listelm)->field.le_next) != NULL)	\
+		(listelm)->field.le_next->field.le_prev =		\
+		    &(elm)->field.le_next;				\
+	(listelm)->field.le_next = (elm);				\
+	(elm)->field.le_prev = &(listelm)->field.le_next;		\
+} while (/*CONSTCOND*/0)
+
+#define	LIST_INSERT_BEFORE(listelm, elm, field) do {			\
+	(elm)->field.le_prev = (listelm)->field.le_prev;		\
+	(elm)->field.le_next = (listelm);				\
+	*(listelm)->field.le_prev = (elm);				\
+	(listelm)->field.le_prev = &(elm)->field.le_next;		\
+} while (/*CONSTCOND*/0)
+
+#define	LIST_INSERT_HEAD(head, elm, field) do {				\
+	if (((elm)->field.le_next = (head)->lh_first) != NULL)		\
+		(head)->lh_first->field.le_prev = &(elm)->field.le_next;\
+	(head)->lh_first = (elm);					\
+	(elm)->field.le_prev = &(head)->lh_first;			\
+} while (/*CONSTCOND*/0)
+
+#define	LIST_REMOVE(elm, field) do {					\
+	if ((elm)->field.le_next != NULL)				\
+		(elm)->field.le_next->field.le_prev = 			\
+		    (elm)->field.le_prev;				\
+	*(elm)->field.le_prev = (elm)->field.le_next;			\
+} while (/*CONSTCOND*/0)
+
+#define	LIST_FOREACH(var, head, field)					\
+	for ((var) = ((head)->lh_first);				\
+		(var);							\
+		(var) = ((var)->field.le_next))
+
+/*
+ * List access methods.
+ */
+#define	LIST_EMPTY(head)		((head)->lh_first == NULL)
+#define	LIST_FIRST(head)		((head)->lh_first)
+#define	LIST_NEXT(elm, field)		((elm)->field.le_next)
+
+
+/*
+ * Singly-linked List definitions.
+ */
+#define	SLIST_HEAD(name, type)						\
+struct name {								\
+	struct type *slh_first;	/* first element */			\
+}
+
+#define	SLIST_HEAD_INITIALIZER(head)					\
+	{ NULL }
+
+#define	SLIST_ENTRY(type)						\
+struct {								\
+	struct type *sle_next;	/* next element */			\
+}
+
+/*
+ * Singly-linked List functions.
+ */
+#define	SLIST_INIT(head) do {						\
+	(head)->slh_first = NULL;					\
+} while (/*CONSTCOND*/0)
+
+#define	SLIST_INSERT_AFTER(slistelm, elm, field) do {			\
+	(elm)->field.sle_next = (slistelm)->field.sle_next;		\
+	(slistelm)->field.sle_next = (elm);				\
+} while (/*CONSTCOND*/0)
+
+#define	SLIST_INSERT_HEAD(head, elm, field) do {			\
+	(elm)->field.sle_next = (head)->slh_first;			\
+	(head)->slh_first = (elm);					\
+} while (/*CONSTCOND*/0)
+
+#define	SLIST_REMOVE_HEAD(head, field) do {				\
+	(head)->slh_first = (head)->slh_first->field.sle_next;		\
+} while (/*CONSTCOND*/0)
+
+#define	SLIST_REMOVE(head, elm, type, field) do {			\
+	if ((head)->slh_first == (elm)) {				\
+		SLIST_REMOVE_HEAD((head), field);			\
+	}								\
+	else {								\
+		struct type *curelm = (head)->slh_first;		\
+		while(curelm->field.sle_next != (elm))			\
+			curelm = curelm->field.sle_next;		\
+		curelm->field.sle_next =				\
+		    curelm->field.sle_next->field.sle_next;		\
+	}								\
+} while (/*CONSTCOND*/0)
+
+#define	SLIST_FOREACH(var, head, field)					\
+	for((var) = (head)->slh_first; (var); (var) = (var)->field.sle_next)
+
+/*
+ * Singly-linked List access methods.
+ */
+#define	SLIST_EMPTY(head)	((head)->slh_first == NULL)
+#define	SLIST_FIRST(head)	((head)->slh_first)
+#define	SLIST_NEXT(elm, field)	((elm)->field.sle_next)
+
+
+/*
+ * Singly-linked Tail queue declarations.
+ */
+#define	STAILQ_HEAD(name, type)					\
+struct name {								\
+	struct type *stqh_first;	/* first element */			\
+	struct type **stqh_last;	/* addr of last next element */		\
+}
+
+#define	STAILQ_HEAD_INITIALIZER(head)					\
+	{ NULL, &(head).stqh_first }
+
+#define	STAILQ_ENTRY(type)						\
+struct {								\
+	struct type *stqe_next;	/* next element */			\
+}
+
+/*
+ * Singly-linked Tail queue functions.
+ */
+#define	STAILQ_INIT(head) do {						\
+	(head)->stqh_first = NULL;					\
+	(head)->stqh_last = &(head)->stqh_first;				\
+} while (/*CONSTCOND*/0)
+
+#define	STAILQ_INSERT_HEAD(head, elm, field) do {			\
+	if (((elm)->field.stqe_next = (head)->stqh_first) == NULL)	\
+		(head)->stqh_last = &(elm)->field.stqe_next;		\
+	(head)->stqh_first = (elm);					\
+} while (/*CONSTCOND*/0)
+
+#define	STAILQ_INSERT_TAIL(head, elm, field) do {			\
+	(elm)->field.stqe_next = NULL;					\
+	*(head)->stqh_last = (elm);					\
+	(head)->stqh_last = &(elm)->field.stqe_next;			\
+} while (/*CONSTCOND*/0)
+
+#define	STAILQ_INSERT_AFTER(head, listelm, elm, field) do {		\
+	if (((elm)->field.stqe_next = (listelm)->field.stqe_next) == NULL)\
+		(head)->stqh_last = &(elm)->field.stqe_next;		\
+	(listelm)->field.stqe_next = (elm);				\
+} while (/*CONSTCOND*/0)
+
+#define	STAILQ_REMOVE_HEAD(head, field) do {				\
+	if (((head)->stqh_first = (head)->stqh_first->field.stqe_next) == NULL) \
+		(head)->stqh_last = &(head)->stqh_first;			\
+} while (/*CONSTCOND*/0)
+
+#define	STAILQ_REMOVE(head, elm, type, field) do {			\
+	if ((head)->stqh_first == (elm)) {				\
+		STAILQ_REMOVE_HEAD((head), field);			\
+	} else {							\
+		struct type *curelm = (head)->stqh_first;		\
+		while (curelm->field.stqe_next != (elm))			\
+			curelm = curelm->field.stqe_next;		\
+		if ((curelm->field.stqe_next =				\
+			curelm->field.stqe_next->field.stqe_next) == NULL) \
+			    (head)->stqh_last = &(curelm)->field.stqe_next; \
+	}								\
+} while (/*CONSTCOND*/0)
+
+#define	STAILQ_FOREACH(var, head, field)				\
+	for ((var) = ((head)->stqh_first);				\
+		(var);							\
+		(var) = ((var)->field.stqe_next))
+
+#define	STAILQ_CONCAT(head1, head2) do {				\
+	if (!STAILQ_EMPTY((head2))) {					\
+		*(head1)->stqh_last = (head2)->stqh_first;		\
+		(head1)->stqh_last = (head2)->stqh_last;		\
+		STAILQ_INIT((head2));					\
+	}								\
+} while (/*CONSTCOND*/0)
+
+/*
+ * Singly-linked Tail queue access methods.
+ */
+#define	STAILQ_EMPTY(head)	((head)->stqh_first == NULL)
+#define	STAILQ_FIRST(head)	((head)->stqh_first)
+#define	STAILQ_NEXT(elm, field)	((elm)->field.stqe_next)
+
+
+/*
+ * Simple queue definitions.
+ */
+#define	SIMPLEQ_HEAD(name, type)					\
+struct name {								\
+	struct type *sqh_first;	/* first element */			\
+	struct type **sqh_last;	/* addr of last next element */		\
+}
+
+#define	SIMPLEQ_HEAD_INITIALIZER(head)					\
+	{ NULL, &(head).sqh_first }
+
+#define	SIMPLEQ_ENTRY(type)						\
+struct {								\
+	struct type *sqe_next;	/* next element */			\
+}
+
+/*
+ * Simple queue functions.
+ */
+#define	SIMPLEQ_INIT(head) do {						\
+	(head)->sqh_first = NULL;					\
+	(head)->sqh_last = &(head)->sqh_first;				\
+} while (/*CONSTCOND*/0)
+
+#define	SIMPLEQ_INSERT_HEAD(head, elm, field) do {			\
+	if (((elm)->field.sqe_next = (head)->sqh_first) == NULL)	\
+		(head)->sqh_last = &(elm)->field.sqe_next;		\
+	(head)->sqh_first = (elm);					\
+} while (/*CONSTCOND*/0)
+
+#define	SIMPLEQ_INSERT_TAIL(head, elm, field) do {			\
+	(elm)->field.sqe_next = NULL;					\
+	*(head)->sqh_last = (elm);					\
+	(head)->sqh_last = &(elm)->field.sqe_next;			\
+} while (/*CONSTCOND*/0)
+
+#define	SIMPLEQ_INSERT_AFTER(head, listelm, elm, field) do {		\
+	if (((elm)->field.sqe_next = (listelm)->field.sqe_next) == NULL)\
+		(head)->sqh_last = &(elm)->field.sqe_next;		\
+	(listelm)->field.sqe_next = (elm);				\
+} while (/*CONSTCOND*/0)
+
+#define	SIMPLEQ_REMOVE_HEAD(head, field) do {				\
+	if (((head)->sqh_first = (head)->sqh_first->field.sqe_next) == NULL) \
+		(head)->sqh_last = &(head)->sqh_first;			\
+} while (/*CONSTCOND*/0)
+
+#define	SIMPLEQ_REMOVE(head, elm, type, field) do {			\
+	if ((head)->sqh_first == (elm)) {				\
+		SIMPLEQ_REMOVE_HEAD((head), field);			\
+	} else {							\
+		struct type *curelm = (head)->sqh_first;		\
+		while (curelm->field.sqe_next != (elm))			\
+			curelm = curelm->field.sqe_next;		\
+		if ((curelm->field.sqe_next =				\
+			curelm->field.sqe_next->field.sqe_next) == NULL) \
+			    (head)->sqh_last = &(curelm)->field.sqe_next; \
+	}								\
+} while (/*CONSTCOND*/0)
+
+#define	SIMPLEQ_FOREACH(var, head, field)				\
+	for ((var) = ((head)->sqh_first);				\
+		(var);							\
+		(var) = ((var)->field.sqe_next))
+
+/*
+ * Simple queue access methods.
+ */
+#define	SIMPLEQ_EMPTY(head)		((head)->sqh_first == NULL)
+#define	SIMPLEQ_FIRST(head)		((head)->sqh_first)
+#define	SIMPLEQ_NEXT(elm, field)	((elm)->field.sqe_next)
+
+
+/*
+ * Tail queue definitions.
+ */
+#define	_TAILQ_HEAD(name, type, qual)					\
+struct name {								\
+	qual type *tqh_first;		/* first element */		\
+	qual type *qual *tqh_last;	/* addr of last next element */	\
+}
+#define TAILQ_HEAD(name, type)	_TAILQ_HEAD(name, struct type,)
+
+#define	TAILQ_HEAD_INITIALIZER(head)					\
+	{ NULL, &(head).tqh_first }
+
+#define	_TAILQ_ENTRY(type, qual)					\
+struct {								\
+	qual type *tqe_next;		/* next element */		\
+	qual type *qual *tqe_prev;	/* address of previous next element */\
+}
+#define TAILQ_ENTRY(type)	_TAILQ_ENTRY(struct type,)
+
+/*
+ * Tail queue functions.
+ */
+#define	TAILQ_INIT(head) do {						\
+	(head)->tqh_first = NULL;					\
+	(head)->tqh_last = &(head)->tqh_first;				\
+} while (/*CONSTCOND*/0)
+
+#define	TAILQ_INSERT_HEAD(head, elm, field) do {			\
+	if (((elm)->field.tqe_next = (head)->tqh_first) != NULL)	\
+		(head)->tqh_first->field.tqe_prev =			\
+		    &(elm)->field.tqe_next;				\
+	else								\
+		(head)->tqh_last = &(elm)->field.tqe_next;		\
+	(head)->tqh_first = (elm);					\
+	(elm)->field.tqe_prev = &(head)->tqh_first;			\
+} while (/*CONSTCOND*/0)
+
+#define	TAILQ_INSERT_TAIL(head, elm, field) do {			\
+	(elm)->field.tqe_next = NULL;					\
+	(elm)->field.tqe_prev = (head)->tqh_last;			\
+	*(head)->tqh_last = (elm);					\
+	(head)->tqh_last = &(elm)->field.tqe_next;			\
+} while (/*CONSTCOND*/0)
+
+#define	TAILQ_INSERT_AFTER(head, listelm, elm, field) do {		\
+	if (((elm)->field.tqe_next = (listelm)->field.tqe_next) != NULL)\
+		(elm)->field.tqe_next->field.tqe_prev = 		\
+		    &(elm)->field.tqe_next;				\
+	else								\
+		(head)->tqh_last = &(elm)->field.tqe_next;		\
+	(listelm)->field.tqe_next = (elm);				\
+	(elm)->field.tqe_prev = &(listelm)->field.tqe_next;		\
+} while (/*CONSTCOND*/0)
+
+#define	TAILQ_INSERT_BEFORE(listelm, elm, field) do {			\
+	(elm)->field.tqe_prev = (listelm)->field.tqe_prev;		\
+	(elm)->field.tqe_next = (listelm);				\
+	*(listelm)->field.tqe_prev = (elm);				\
+	(listelm)->field.tqe_prev = &(elm)->field.tqe_next;		\
+} while (/*CONSTCOND*/0)
+
+#define	TAILQ_REMOVE(head, elm, field) do {				\
+	if (((elm)->field.tqe_next) != NULL)				\
+		(elm)->field.tqe_next->field.tqe_prev = 		\
+		    (elm)->field.tqe_prev;				\
+	else								\
+		(head)->tqh_last = (elm)->field.tqe_prev;		\
+	*(elm)->field.tqe_prev = (elm)->field.tqe_next;			\
+} while (/*CONSTCOND*/0)
+
+#define	TAILQ_FOREACH(var, head, field)					\
+	for ((var) = ((head)->tqh_first);				\
+		(var);							\
+		(var) = ((var)->field.tqe_next))
+
+#define	TAILQ_FOREACH_REVERSE(var, head, headname, field)		\
+	for ((var) = (*(((struct headname *)((head)->tqh_last))->tqh_last));	\
+		(var);							\
+		(var) = (*(((struct headname *)((var)->field.tqe_prev))->tqh_last)))
+
+#define	TAILQ_CONCAT(head1, head2, field) do {				\
+	if (!TAILQ_EMPTY(head2)) {					\
+		*(head1)->tqh_last = (head2)->tqh_first;		\
+		(head2)->tqh_first->field.tqe_prev = (head1)->tqh_last;	\
+		(head1)->tqh_last = (head2)->tqh_last;			\
+		TAILQ_INIT((head2));					\
+	}								\
+} while (/*CONSTCOND*/0)
+
+/*
+ * Tail queue access methods.
+ */
+#define	TAILQ_EMPTY(head)		((head)->tqh_first == NULL)
+#define	TAILQ_FIRST(head)		((head)->tqh_first)
+#define	TAILQ_NEXT(elm, field)		((elm)->field.tqe_next)
+
+#define	TAILQ_LAST(head, headname) \
+	(*(((struct headname *)((head)->tqh_last))->tqh_last))
+#define	TAILQ_PREV(elm, headname, field) \
+	(*(((struct headname *)((elm)->field.tqe_prev))->tqh_last))
+
+
+/*
+ * Circular queue definitions.
+ */
+#define	CIRCLEQ_HEAD(name, type)					\
+struct name {								\
+	struct type *cqh_first;		/* first element */		\
+	struct type *cqh_last;		/* last element */		\
+}
+
+#define	CIRCLEQ_HEAD_INITIALIZER(head)					\
+	{ (void *)&head, (void *)&head }
+
+#define	CIRCLEQ_ENTRY(type)						\
+struct {								\
+	struct type *cqe_next;		/* next element */		\
+	struct type *cqe_prev;		/* previous element */		\
+}
+
+/*
+ * Circular queue functions.
+ */
+#define	CIRCLEQ_INIT(head) do {						\
+	(head)->cqh_first = (void *)(head);				\
+	(head)->cqh_last = (void *)(head);				\
+} while (/*CONSTCOND*/0)
+
+#define	CIRCLEQ_INSERT_AFTER(head, listelm, elm, field) do {		\
+	(elm)->field.cqe_next = (listelm)->field.cqe_next;		\
+	(elm)->field.cqe_prev = (listelm);				\
+	if ((listelm)->field.cqe_next == (void *)(head))		\
+		(head)->cqh_last = (elm);				\
+	else								\
+		(listelm)->field.cqe_next->field.cqe_prev = (elm);	\
+	(listelm)->field.cqe_next = (elm);				\
+} while (/*CONSTCOND*/0)
+
+#define	CIRCLEQ_INSERT_BEFORE(head, listelm, elm, field) do {		\
+	(elm)->field.cqe_next = (listelm);				\
+	(elm)->field.cqe_prev = (listelm)->field.cqe_prev;		\
+	if ((listelm)->field.cqe_prev == (void *)(head))		\
+		(head)->cqh_first = (elm);				\
+	else								\
+		(listelm)->field.cqe_prev->field.cqe_next = (elm);	\
+	(listelm)->field.cqe_prev = (elm);				\
+} while (/*CONSTCOND*/0)
+
+#define	CIRCLEQ_INSERT_HEAD(head, elm, field) do {			\
+	(elm)->field.cqe_next = (head)->cqh_first;			\
+	(elm)->field.cqe_prev = (void *)(head);				\
+	if ((head)->cqh_last == (void *)(head))				\
+		(head)->cqh_last = (elm);				\
+	else								\
+		(head)->cqh_first->field.cqe_prev = (elm);		\
+	(head)->cqh_first = (elm);					\
+} while (/*CONSTCOND*/0)
+
+#define	CIRCLEQ_INSERT_TAIL(head, elm, field) do {			\
+	(elm)->field.cqe_next = (void *)(head);				\
+	(elm)->field.cqe_prev = (head)->cqh_last;			\
+	if ((head)->cqh_first == (void *)(head))			\
+		(head)->cqh_first = (elm);				\
+	else								\
+		(head)->cqh_last->field.cqe_next = (elm);		\
+	(head)->cqh_last = (elm);					\
+} while (/*CONSTCOND*/0)
+
+#define	CIRCLEQ_REMOVE(head, elm, field) do {				\
+	if ((elm)->field.cqe_next == (void *)(head))			\
+		(head)->cqh_last = (elm)->field.cqe_prev;		\
+	else								\
+		(elm)->field.cqe_next->field.cqe_prev =			\
+		    (elm)->field.cqe_prev;				\
+	if ((elm)->field.cqe_prev == (void *)(head))			\
+		(head)->cqh_first = (elm)->field.cqe_next;		\
+	else								\
+		(elm)->field.cqe_prev->field.cqe_next =			\
+		    (elm)->field.cqe_next;				\
+} while (/*CONSTCOND*/0)
+
+#define	CIRCLEQ_FOREACH(var, head, field)				\
+	for ((var) = ((head)->cqh_first);				\
+		(var) != (const void *)(head);				\
+		(var) = ((var)->field.cqe_next))
+
+#define	CIRCLEQ_FOREACH_REVERSE(var, head, field)			\
+	for ((var) = ((head)->cqh_last);				\
+		(var) != (const void *)(head);				\
+		(var) = ((var)->field.cqe_prev))
+
+/*
+ * Circular queue access methods.
+ */
+#define	CIRCLEQ_EMPTY(head)		((head)->cqh_first == (void *)(head))
+#define	CIRCLEQ_FIRST(head)		((head)->cqh_first)
+#define	CIRCLEQ_LAST(head)		((head)->cqh_last)
+#define	CIRCLEQ_NEXT(elm, field)	((elm)->field.cqe_next)
+#define	CIRCLEQ_PREV(elm, field)	((elm)->field.cqe_prev)
+
+#define CIRCLEQ_LOOP_NEXT(head, elm, field)				\
+	(((elm)->field.cqe_next == (void *)(head))			\
+	    ? ((head)->cqh_first)					\
+	    : (elm->field.cqe_next))
+#define CIRCLEQ_LOOP_PREV(head, elm, field)				\
+	(((elm)->field.cqe_prev == (void *)(head))			\
+	    ? ((head)->cqh_last)					\
+	    : (elm->field.cqe_prev))
+
+#endif	/* sys/queue.h */


### PR DESCRIPTION
Hi,

I needed to get a Windows version of the IDS python wrapper, so I adapted the ncsuarc/ids code to make it compilable using the Windows SDK according to [Readthedocs](http://haypo-notes.readthedocs.org/python.html#compile-python-extensions-on-windows). Unfortunately, this required quite some changes to the code so that the MS compiler accepts it as C89. It should still work on Linux, but I wasn't able to test this.

Thanks,
Philiipp
